### PR TITLE
Make curriculum box clickable in full

### DIFF
--- a/_includes/curriculum.html
+++ b/_includes/curriculum.html
@@ -1,15 +1,15 @@
 <blockquote class="callout">
-  <h2 style="">HSF Software Training</h2>
-  <div style="width: 100px; position: absolute;">
-    <a href="https://hepsoftwarefoundation.org">
+  <a href="https://hepsoftwarefoundation.org/training/curriculum.html" style="color: inherit; text-decoration: none;">
+    <h2 style="">HSF Software Training</h2>
+    <div style="width: 100px; position: absolute;">
       <img src="./{{ relative_root_path }}/assets/img/hsf-logo.png" alt="HSF Logo" height=75px style="margin: 0px;"/>
-    </a>
-  </div>
-  <div style="margin-left: 115px; position: relative; min-height: 75px">
-    This training module is part of the
-    <a href="https://hepsoftwarefoundation.org/training/curriculum.html">HSF Software Training Center</a>, a
-    series of training modules that serves HEP newcomers the
-    software skills needed as they enter the field,
-    and in parallel, instill best practices for writing software.
-  </div>
+    </div>
+    <div style="margin-left: 115px; position: relative; min-height: 75px">
+      This training module is part of the
+      <b>HSF Software Training Center</b>, a
+      series of training modules that serves HEP newcomers the
+      software skills needed as they enter the field,
+      and in parallel, instill best practices for writing software.
+    </div>
+  </a>
 </blockquote>


### PR DESCRIPTION
@henryiii had mentioned that finding the link to the training center was easy to miss in the box. As suggested by him, now the full box is clickable.